### PR TITLE
enhance comm scc 

### DIFF
--- a/core/scc/commscc/commscc.go
+++ b/core/scc/commscc/commscc.go
@@ -8,6 +8,7 @@ package commscc
 
 import (
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"strconv"
@@ -17,7 +18,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
-	"github.com/hyperledger/fabric/gossip/comm"
+	"github.com/hyperledger/fabric/gossip/discovery"
+	gossip_svc "github.com/hyperledger/fabric/gossip/gossip"
 	"github.com/hyperledger/fabric/gossip/service"
 	"github.com/hyperledger/fabric/gossip/util"
 	"github.com/hyperledger/fabric/protos/gossip"
@@ -30,50 +32,63 @@ var logger = flogging.MustGetLogger("commscc")
 const (
 	SEND    = "send"
 	RECEIVE = "receive"
+
+	// maxMessageSaveTime denotes the maximum period of time to save a message
+	// in memory until it is purged
+	maxMessageSaveTime = time.Second * 10
+
+	ackWaitTime = time.Second * 3
 )
 
 type action func(stub shim.ChaincodeStubInterface) pb.Response
 
 type CommSCC struct {
-	pubSub *util.PubSub
-
+	pubSub  *util.PubSub
 	actions map[string]action
+	gossip_svc.Gossip
+	msgStore *MessageStore
+}
 
-	rmc chan comm.ReceivedMessageImpl
+func NewCommSCC() *CommSCC {
+	c := &CommSCC{
+		pubSub:   util.NewPubSub(),
+		Gossip:   service.GetGossipService(),
+		msgStore: NewMessageStore(),
+	}
+	c.actions = map[string]action{
+		SEND:    c.send,
+		RECEIVE: c.receive,
+	}
+	go c.listen()
+	return c
+}
+
+func (scc *CommSCC) listen() {
+	_, rmc := scc.Accept(mpcMessageAcceptor, true)
+	for msg := range rmc {
+		mpcMsg := msg.GetGossipMessage().GetMpcData()
+		session := mpcMsg.Payload.SessionID
+		addr := msg.GetConnectionInfo().Endpoint
+		logger.Debugf("Message from %s in session %s, contains payload of %d bytes", addr, string(session), len(mpcMsg.Payload.Data))
+		// Notify the other side we've received the message
+		msg.Ack(nil)
+		// Probe to see if some receive operation is interested in this session
+		err := scc.pubSub.Publish(hex.EncodeToString(session), msg)
+		if err == nil {
+			continue
+		}
+		// If the publish failed we need to save the message
+		scc.msgStore.Put(hex.EncodeToString(session), msg)
+
+		// Cleanup in any case
+		time.AfterFunc(maxMessageSaveTime, func() {
+			scc.msgStore.Remove(hex.EncodeToString(session))
+		})
+	}
 }
 
 func (scc *CommSCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
-	defer logger.Infof("Successfully initialized CommSCC.")
-
-	scc.actions = map[string]action{}
-
-	// Define the functions the chaincode handles
-	scc.actions[SEND] = scc.send
-	scc.actions[RECEIVE] = scc.receive
-
-	// SHAI: Do we really need this? Otherwise scc.PubSub.Subscribe in commscc.go crashes when trying to lock at line
-	scc.pubSub = util.NewPubSub()
-
-	// Start listening to MPC messages.
-	// This needs to be called once and for all.
-	_, rmc := service.GetGossipService().Accept(scc.mpcMessageAcceptor, true)
-	go func() {
-		// TODO: do we need a way to exit the loop?
-		logger.Infof("Listen to RMC queue...")
-		for msg := range rmc {
-			logger.Infof("Publish [%v] to [%v]", msg, string(msg.GetGossipMessage().GetMpcData().Payload.SessionID))
-
-			// Publish the message using as topic the session ID.
-			// Session ID can be chosen arbitrarily. One way to choose it
-			// is by setting it to the transaction ID.
-			err := scc.pubSub.Publish(string(msg.GetGossipMessage().GetMpcData().Payload.SessionID), msg)
-			if err != nil {
-				// TODO: cache the message and give it a chance to reappear later
-				logger.Errorf("Failed publishing [%v] to [%v]. Err [%s]", msg, string(msg.GetGossipMessage().GetMpcData().Payload.SessionID), err)
-			}
-		}
-	}()
-
+	logger.Infof("Successfully initialized CommSCC.")
 	return shim.Success(nil)
 }
 
@@ -101,22 +116,32 @@ func (scc *CommSCC) send(stub shim.ChaincodeStubInterface) pb.Response {
 
 	logger.Infof("[%v] Send [%v] to [%v]", string(sessionID), string(payload), endpoint)
 
-	// TODO: replace this with one with SendByCriteria to receive an ack
-	service.GetGossipService().Send(
-		&gossip.GossipMessage{
-			Nonce: 0,
-			// TODO: Which tag works better here?
-			//Tag:     gossip.GossipMessage_CHAN_AND_ORG,
-			Content: &gossip.GossipMessage_MpcData{
-				MpcData: &gossip.MPCDataMessage{Payload: &gossip.MPCPayload{
-					SessionID: sessionID,
-					Data:      payload,
-				}},
-			},
+	msg := &gossip.GossipMessage{
+		Nonce: 0,
+		Content: &gossip.GossipMessage_MpcData{
+			MpcData: &gossip.MPCDataMessage{Payload: &gossip.MPCPayload{
+				SessionID: sessionID,
+				Data:      payload,
+			}},
 		},
-		&comm.RemotePeer{Endpoint: endpoint},
-	)
+	}
+	sMsg, err := msg.NoopSign()
+	if err != nil {
+		logger.Panicf("Failed marshaling gossip message: %v", err)
+	}
 
+	err = scc.SendByCriteria(sMsg, gossip_svc.SendCriteria{
+		MaxPeers: 1,
+		MinAck:   1,
+		Timeout:  ackWaitTime,
+		IsEligible: func(member discovery.NetworkMember) bool {
+			return member.PreferredEndpoint() == endpoint
+		},
+	})
+	if err != nil {
+		logger.Warningf("Failed sending message to %s: %v", endpoint, err)
+		return shim.Error(fmt.Sprintf("failed sending message to %s: %v", endpoint, err))
+	}
 	return shim.Success(nil)
 }
 
@@ -137,54 +162,60 @@ func (scc *CommSCC) receive(stub shim.ChaincodeStubInterface) pb.Response {
 
 	logger.Infof("Receive on [%v]", topic)
 
+	var totalMessages []gossip.ReceivedMessage
+	// First, check if we have messages waiting for us
+	waitingMessages := scc.msgStore.MsgsByID(topic)
+	totalMessages = append(totalMessages, waitingMessages...)
+	scc.msgStore.Remove(topic)
+
 	// Wait for the message on the given topic for a given amount of time
-	// TODO: allow the invoker to specify the timeout
 	sub := scc.pubSub.Subscribe(topic, time.Millisecond*time.Duration(timeout))
-	msgRaw, err := sub.Listen()
-	if err != nil {
-		logger.Errorf("[%v] failed receive [%s]", topic, err)
-		return shim.Error(fmt.Sprintf("[%v] failed receive [%s]", topic, err))
+	for {
+		msgRaw, err := sub.Listen()
+		if err != nil {
+			break
+		}
+		msg := msgRaw.(gossip.ReceivedMessage)
+		totalMessages = append(totalMessages, msg)
 	}
 
-	msg := msgRaw.(gossip.ReceivedMessage)
-
-	sID := &msp.SerializedIdentity{}
-	proto.Unmarshal(msg.GetConnectionInfo().Identity, sID)
-	bl, _ := pem.Decode(sID.IdBytes)
-	cert, _ := x509.ParseCertificate(bl.Bytes)
-	actualEndPoint := cert.Subject.CommonName
-
-	// Check the certificate to tell who is the sender
-	if strings.Compare(strings.Split(endpoint, ":")[0], actualEndPoint) != 0 {
-		logger.Errorf("Expected to receive msg from [%s], not [%s]", endpoint, actualEndPoint)
-		return shim.Error(fmt.Sprintf("Expected to receive msg from [%s], not [%s]", endpoint, actualEndPoint))
+	msg := findMessage(totalMessages, endpoint)
+	if msg == nil {
+		return shim.Error(fmt.Sprintf("Didn't receive any message from %s on session %s, but did receive %d messages", endpoint, topic, len(totalMessages)))
 	}
-
 	// Given init, we expect to see a ReceivedMessage here.
 	mpcData := msg.GetGossipMessage().GetMpcData()
-	if mpcData == nil {
-		logger.Errorf("[%v] received empty mpc message.", topic)
-		return shim.Error(fmt.Sprintf("[%s] received empty mpc message.", topic))
-	}
-
 	logger.Infof("Received on [%v], [%v]", topic, mpcData.Payload.Data)
 
 	// TODO: check that payload is different from nil
-
 	return shim.Success(mpcData.Payload.Data)
 }
 
-func (scc *CommSCC) mpcMessageAcceptor(input interface{}) bool {
+func findMessage(msgs []gossip.ReceivedMessage, endpoint string) gossip.ReceivedMessage {
+	for _, msg := range msgs {
+		sID := &msp.SerializedIdentity{}
+		proto.Unmarshal(msg.GetConnectionInfo().Identity, sID)
+		bl, _ := pem.Decode(sID.IdBytes)
+		cert, _ := x509.ParseCertificate(bl.Bytes)
+		actualEndPoint := cert.Subject.CommonName
+
+		// Check the certificate to tell who is the sender
+		if strings.Compare(strings.Split(endpoint, ":")[0], actualEndPoint) != 0 {
+			logger.Warningf("Expected to receive msg from [%s], not [%s]", endpoint, actualEndPoint)
+			continue
+		}
+		return msg
+	}
+	return nil
+}
+
+func mpcMessageAcceptor(input interface{}) bool {
 	// input is supposed to be of type ReceivedMessage.
 	// If it is not the case, return false
 	msg, ok := input.(gossip.ReceivedMessage)
 	if !ok {
 		// Not a ReceivedMessage
 		return false
-	}
-
-	if msg.GetGossipMessage().IsMpcData() {
-		logger.Infof("Intercepted [%v], [%v], [%v]", msg, ok, msg.GetGossipMessage().IsMpcData())
 	}
 
 	// Is this message an MPC message?

--- a/core/scc/commscc/commscc.go
+++ b/core/scc/commscc/commscc.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hyperledger/fabric/protos/gossip"
 	"github.com/hyperledger/fabric/protos/msp"
 	pb "github.com/hyperledger/fabric/protos/peer"
-	"sync"
 	"github.com/hyperledger/fabric/gossip/service"
 )
 
@@ -43,7 +42,6 @@ const (
 type action func(stub shim.ChaincodeStubInterface) pb.Response
 
 type CommSCC struct {
-	sync.Mutex
 	pubSub  *util.PubSub
 	actions map[string]action
 	gossip_svc.Gossip

--- a/core/scc/commscc/msgStore.go
+++ b/core/scc/commscc/msgStore.go
@@ -1,0 +1,58 @@
+package commscc
+
+import (
+	"sync"
+	"github.com/hyperledger/fabric/protos/gossip"
+)
+
+// MessageStore struct that encapsulates
+// message storage
+type MessageStore struct {
+	m map[string][]gossip.ReceivedMessage
+	sync.RWMutex
+}
+
+// NewMessageStore creates new message store instance
+func NewMessageStore() *MessageStore {
+	return &MessageStore{m: make(map[string][]gossip.ReceivedMessage)}
+}
+
+// MsgsByID returns messages stored by a certain ID, or nil
+// if such an ID isn't found
+func (m *MessageStore) MsgsByID(id string) []gossip.ReceivedMessage {
+	m.RLock()
+	defer m.RUnlock()
+	if msgs, exists := m.m[id]; exists {
+		return msgs
+	}
+	return nil
+}
+
+// Put associates msg with the given ID
+func (m *MessageStore) Put(id string, msg gossip.ReceivedMessage) {
+	m.Lock()
+	defer m.Unlock()
+	m.m[id] = append(m.m[id], msg)
+}
+
+// Remove removes a message with a given ID
+func (m *MessageStore) Remove(id string) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.m, id)
+}
+/*
+// ToSlice returns a slice backed by the elements
+// of the MessageStore
+func (m *MessageStore) ToSlice() []gossip.ReceivedMessage {
+	m.RLock()
+	defer m.RUnlock()
+	messages := make([]gossip.ReceivedMessage, len(m.m))
+	i := 0
+	for _, member := range m.m {
+		messages[i] = member
+		i++
+	}
+	return messages
+}
+*/

--- a/core/scc/importsysccs.go
+++ b/core/scc/importsysccs.go
@@ -85,7 +85,7 @@ var systemChaincodes = []*SystemChaincode{
 		Name:              "commscc",
 		Path:              "github.com/hyperledger/fabric/core/scc/commscc",
 		InitArgs:          [][]byte{[]byte("")},
-		Chaincode:         &commscc.CommSCC{},
+		Chaincode:         commscc.NewCommSCC(),
 		InvokableExternal: false, // commscc cannot be invoked externally
 		InvokableCC2CC:    true,  // commscc can be invoked from a cc
 	},

--- a/examples/mpc_e2e_cli/base/peer-base.yaml
+++ b/examples/mpc_e2e_cli/base/peer-base.yaml
@@ -14,7 +14,7 @@ services:
       # https://docs.docker.com/compose/networking/
       - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=mpce2ecli_default
       #- CORE_LOGGING_LEVEL=ERROR
-      - CORE_LOGGING_LEVEL=DEBUG
+      - CORE_LOGGING_LEVEL=INFO
       - CORE_PEER_TLS_ENABLED=true
       - CORE_PEER_GOSSIP_USELEADERELECTION=true
       - CORE_PEER_GOSSIP_ORGLEADER=false

--- a/examples/mpc_e2e_cli/config/core.yaml
+++ b/examples/mpc_e2e_cli/config/core.yaml
@@ -46,13 +46,13 @@ logging:
     # Note: the modules listed below are the only acceptable modules at this
     #       time.
     cauthdsl:   warning
-    gossip:     debug
+    gossip:     warning
+    commscc:    debug
     grpc:       error
     ledger:     info
     msp:        warning
     policies:   warning
-    peer:
-        gossip: warning
+    shim:       warning
 
     # Message format for the peer logs
     format: '%{color}%{time:2006-01-02 15:04:05.000 MST} [%{module}] %{shortfunc} -> %{level:.4s} %{id:03x}%{color:reset} %{message}'

--- a/examples/mpc_e2e_cli/config/decorations_1.yaml
+++ b/examples/mpc_e2e_cli/config/decorations_1.yaml
@@ -1,3 +1,3 @@
 master: "true"
 target: peer1.org1.example.com:7051
-input: 1
+input: 541

--- a/examples/mpc_e2e_cli/config/decorations_2.yaml
+++ b/examples/mpc_e2e_cli/config/decorations_2.yaml
@@ -1,3 +1,3 @@
 master: "false"
 target: peer0.org1.example.com:7051
-input: 2
+input: 487

--- a/examples/mpc_e2e_cli/config/decorations_3.yaml
+++ b/examples/mpc_e2e_cli/config/decorations_3.yaml
@@ -1,3 +1,3 @@
 master: "true"
 target: peer1.org2.example.com:7051
-input: 3
+input: 150

--- a/examples/mpc_e2e_cli/config/decorations_4.yaml
+++ b/examples/mpc_e2e_cli/config/decorations_4.yaml
@@ -1,3 +1,3 @@
 master: "false"
 target: peer0.org2.example.com:7051
-input: 4
+input: 200

--- a/examples/mpc_e2e_cli/scripts/script.sh
+++ b/examples/mpc_e2e_cli/scripts/script.sh
@@ -254,7 +254,58 @@ chaincodeQuery 1 100
 #Invoke on chaincode on Peer0/Org1 + Peer1/Org1
 echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
 chaincodeInvoke 0
-
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
+echo "Sending invoke transaction on org1/peer0 + org1/peer1..."
+chaincodeInvoke 0
 echo
 echo "===================== All GOOD, End-2-End execution completed ===================== "
 echo

--- a/gossip/service/gossip_service.go
+++ b/gossip/service/gossip_service.go
@@ -167,6 +167,9 @@ func InitGossipServiceCustomDeliveryFactory(peerIdentity []byte, endpoint string
 
 // GetGossipService returns an instance of gossip service
 func GetGossipService() GossipService {
+	if gossipServiceInstance == nil {
+		return nil
+	}
 	return gossipServiceInstance
 }
 

--- a/peer/chaincode/common.go
+++ b/peer/chaincode/common.go
@@ -27,6 +27,8 @@ import (
 	"golang.org/x/net/context"
 	"sync"
 	"github.com/spf13/viper"
+	"math/rand"
+	"time"
 )
 
 // checkSpec to see if chaincode resides within current package capture for language.
@@ -346,11 +348,12 @@ func ChaincodeInvokeOrQuery(
 	var proposalResponseErrs []error
 	var wg sync.WaitGroup
 
+	rand.Seed(time.Now().UnixNano())
 	for _, endorserClient := range endorserClients {
 		wg.Add(1)
 		go func(endorserClient pb.EndorserClient) {
 			defer wg.Done()
-
+			time.Sleep(time.Duration(rand.Int31n(500)) * time.Millisecond )
 			proposalResp, err := endorserClient.ProcessProposal(context.Background(), signedProp)
 			if err != nil {
 				responseMtx.Lock()


### PR DESCRIPTION
- commscc: I added support for messages that arrive when no one is calling receive yet.
- mpc_e2e_cli:  I changed the use case to something more complex:  
              -  Each of the peers sends to the other his number
              - Waits for the other number
              - Compute the multiplication, 
              - Send the other peer his result
              - Waits for the result from the other peer and compare the results.
              - Fails, if the other peer computed a different result.
While that wasn't the use case before that - it clearly demonstrates the capability of the comm scc and should be used as an example from which the real use case of the MPC can be built.
- I changed the script **examples/mpc_e2e_cli/scripts/script.sh** to invoke a large number of times, to test that it works with a good probability (doesn't fail to me... but, there is no proof that it works **w.h.p** 
- I injected a random sleep in **peer/chaincode/common.go** to add chaos into the test, to try make it fail if the code is not stable. 
It works also if i remove it :) 


